### PR TITLE
feat(metrics): default http request labels

### DIFF
--- a/example/metrics/main.go
+++ b/example/metrics/main.go
@@ -23,8 +23,9 @@ func main() {
 
 	// instantiate new metrics server
 	metricsConfig := spec.MetricsServerConfig{
-		ServiceName: "",
-		Ctx:         ctx,
+		ServiceName:   "basicapp",
+		Ctx:           ctx,
+		DefaultLabels: []string{"environment", "development"},
 	}
 	ms, err := spec.NewDefaultMetricsServer(metricsConfig)
 	if err != nil {


### PR DESCRIPTION
adds the ability to inject default labels into http request metrics.
includes `appName` by default.