### PR TITLE
chore(metrics): Remove enabled hostname from metrics config

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -47,7 +47,16 @@ func NewDefaultMetricsServer(cfg MetricsServerConfig) (*MetricsServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	m, err := metrics.New(metrics.DefaultConfig(""), sink)
+	mc := &metrics.Config{
+		ServiceName:          cfg.ServiceName,
+		EnableHostname:       false, // if true the hostname/pod gets prepended to gauge metrics in Prom/NR (ie spin_terraformer_857fb9b884_97nrn_my_metric)
+		EnableRuntimeMetrics: true,
+		EnableTypePrefix:     false,
+		TimerGranularity:     time.Millisecond,
+		ProfileInterval:      time.Second,
+		FilterDefault:        true,
+	}
+	m, err := metrics.New(mc, sink)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The aim of this PR is to the remove the prefixed pod name from gauge metrics, ie `spin_terraformer_857fb9b884_97nrn_jobs_inflight`.

**Changes:**
- Set `EnableHostname` to false. The rest of the config that we were using was from the Default Config here: https://github.com/armon/go-metrics/blob/2bc64ebd2914430b52dfc5c90c00722afec193ba/start.go#L57.
- Use the service name in the config

The above metric would look like `terraformer_jobs_inflight` in Terraformer with these changes.