### PR TITLE
fix(logs): remove panic from Logrus adapter

### DIFF
--- a/logging/logrus.go
+++ b/logging/logrus.go
@@ -12,5 +12,6 @@ func (l *LogrusAdapter) WithField(key string, value interface{}) LeveledLogger {
 }
 
 func (l *LogrusAdapter) WithFields(fields map[string]interface{}) LeveledLogger {
-	panic("implement me")
+	withFields := l.Logger.WithFields(fields)
+	return &LogrusAdapter{withFields}
 }


### PR DESCRIPTION
I was playing around with the logger and ran into this panic for Terraformer. Looks like it was missed.